### PR TITLE
Change package URLs to epiforecasts.io

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,9 +24,9 @@ Description: Provides methods to simulate and analyse the size and length
     or length of infectious disease outbreaks, as discussed in Farrington
     et al. (2003) <doi:10.1093/biostatistics/4.2.279>.
 License: MIT + file LICENSE
-URL: https://github.com/epiverse-trace/bpmodels,
-    https://epiverse-trace.github.io/bpmodels/
-BugReports: https://github.com/epiverse-trace/bpmodels/issues
+URL: https://github.com/epiforecasts/bpmodels,
+    https://epiforecasts.io/bpmodels/
+BugReports: https://github.com/epiforecasts/bpmodels/issues
 Depends:
     R (>= 3.6.0)
 Suggests:

--- a/README.Rmd
+++ b/README.Rmd
@@ -45,7 +45,7 @@ The latest development version of the _bpmodels_ package can be installed via
 ```{r eval=FALSE}
 # check whether {pak} is installed
 if (!require("pak")) install.packages("pak")
-pak::pkg_install("epiverse-trace/bpmodels")
+pak::pkg_install("epiforecasts/bpmodels")
 ```
 
 To load the package, use

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ installed via
 ``` r
 # check whether {pak} is installed
 if (!require("pak")) install.packages("pak")
-pak::pkg_install("epiverse-trace/bpmodels")
+pak::pkg_install("epiforecasts/bpmodels")
 ```
 
 To load the package, use

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: https://epiverse-trace.github.io/bpmodels/
+url: https://epiforecasts.io/bpmodels/
 
 template:
   package: epiversetheme


### PR DESCRIPTION
This PR fixes #147 by changing the epiverse-trace URLs to epiforecasts as part of retiring the package.