### PR TITLE
Replace `epiversetheme` with darkly

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,7 +1,9 @@
 url: https://epiforecasts.io/bpmodels/
 
 template:
-  package: epiversetheme
+  bootstrap: 5
+  math-rendering: katex
+  bootswatch: darkly
   bslib:
     font_weight_base : 300
 

--- a/vignettes/bpmodels.Rmd
+++ b/vignettes/bpmodels.Rmd
@@ -5,8 +5,6 @@ output:
   bookdown::html_vignette2:
     fig_caption: yes
     code_folding: show
-pkgdown:
-  as_is: true
 bibliography: references.json
 link-citations: true
 vignette: >

--- a/vignettes/branching_process_literature.Rmd
+++ b/vignettes/branching_process_literature.Rmd
@@ -4,8 +4,6 @@ output:
   bookdown::html_vignette2:
     fig_caption: yes
     code_folding: show
-pkgdown:
-  as_is: true
 bibliography: branching_process_literature.json
 link-citations: true
 vignette: >

--- a/vignettes/projecting_incidence.Rmd
+++ b/vignettes/projecting_incidence.Rmd
@@ -5,8 +5,6 @@ output:
   bookdown::html_vignette2:
     fig_caption: yes
     code_folding: show
-pkgdown:
-  as_is: true
 bibliography: references.json
 link-citations: true
 vignette: >

--- a/vignettes/theoretical_background.Rmd
+++ b/vignettes/theoretical_background.Rmd
@@ -5,8 +5,6 @@ output:
   bookdown::html_vignette2:
     fig_caption: yes
     code_folding: show
-pkgdown:
-  as_is: true
 bibliography: references.json
 link-citations: true
 vignette: >


### PR DESCRIPTION
Since this package is no longer being maintained under the Epiverse-Trace initiative, it makes sense to remove the epiverse trace theme. This PR replaces the epiverse theme with `darkly` and removes the `pkgdown: as_is` setting so that the equations in the vignettes can render.