### PR TITLE
Change note in README to warning

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -24,9 +24,9 @@ knitr::opts_chunk$set(
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/license/MIT/)
 <!-- badges: end -->
 
-## Note
 
-> `{bpmodels}` is now *retired and will no longer be maintained*. We recommend using [`{epichains}`](https://github.com/epiverse-trace/epichains) instead. If you need help converting your code to use `{epichains}`, please [open a discussion on epichains](https://github.com/epiverse-trace/epichains/discussions).
+> [!WARNING]
+`{bpmodels}` is now *retired and will no longer be maintained*. We recommend using [`{epichains}`](https://github.com/epiverse-trace/epichains) instead. If you need help converting your code to use `{epichains}`, please [open a discussion on epichains](https://github.com/epiverse-trace/epichains/discussions).
 
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = TRUE)

--- a/README.md
+++ b/README.md
@@ -15,10 +15,8 @@ contributors](https://img.shields.io/github/contributors/epiverse-trace/bpmodels
 MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/license/MIT/)
 <!-- badges: end -->
 
-## Note
-
-> `{bpmodels}` is now *retired and will no longer be maintained*. We
-> recommend using
+> \[!WARNING\] `{bpmodels}` is now *retired and will no longer be
+> maintained*. We recommend using
 > [`{epichains}`](https://github.com/epiverse-trace/epichains) instead.
 > If you need help converting your code to use `{epichains}`, please
 > [open a discussion on


### PR DESCRIPTION
This PR changes the note heading in the README to a more prominent warning note for visual clarity.